### PR TITLE
Silence useless LOOP_GET_STATUS64 warnings

### DIFF
--- a/Loop.cpp
+++ b/Loop.cpp
@@ -150,7 +150,9 @@ int Loop::destroyAll() {
 
         struct loop_info64 li;
         if (ioctl(fd.get(), LOOP_GET_STATUS64, &li) < 0) {
-            PLOG(WARNING) << "Failed to LOOP_GET_STATUS64 " << path;
+            if (errno != ENXIO) {
+                PLOG(WARNING) << "Failed to LOOP_GET_STATUS64 " << path;
+            }
             continue;
         }
 


### PR DESCRIPTION
When vold starts up, there are lots of warnings like:

    W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop30: No such device or address
    W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop29: No such device or address
    W vold    : Failed to LOOP_GET_STATUS64 /dev/block/loop28: No such device or address

vold is iterating through all loop devices and unbinding the file from
any vold-managed ones.

It's expected that not all loop devices have a file bound to them,
however.  On these, LOOP_GET_STATUS64 fails with ENXIO.

Don't print a warning in such cases.

Change-Id: I91755259dc2c09b1869627259d1e59d5edd6f145