### PR TITLE
Use tidy_checks_as_errors not -warnings-as-errors

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -23,8 +23,9 @@ cc_defaults {
         "clang-analyzer-security*",
         "android-*",
     ],
-    tidy_flags: [
-        "-warnings-as-errors=clang-analyzer-security*,cert-*",
+    tidy_checks_as_errors: [
+        "clang-analyzer-security*",
+        "cert-*",
     ],
 }
 


### PR DESCRIPTION
The flag -warnings-as-errors embedded in tidy_flags
is difficult to process and error-prone.
They should be replaced with the new tidy_checks_as_errors list.

Bug: 229801437
Test: make tidy-system-vold
Change-Id: I801e73dce5f08fe1ca5bc49de633706ad2cdf986